### PR TITLE
Add guard clause for undefined onChange

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@launchpadlab/lp-form",
-  "version": "2.8.0",
+  "version": "2.8.1",
   "description": "Extensions for the reduxForm HOC",
   "main": "lib/index.js",
   "scripts": {

--- a/src/middleware/ignorePristineOnChange.js
+++ b/src/middleware/ignorePristineOnChange.js
@@ -4,9 +4,9 @@ import { withPropsOnChange } from 'recompose'
 const ignorePristineOnChange = withPropsOnChange(
   ['onChange'],
   ({ onChange }) => {
+    if (!onChange) return {}
     return {
       onChange: (params, dispatch, props, ...rest) => {
-        if (!onChange) return
         if (props.pristine && !props.anyTouched) return
         return onChange(params, dispatch, props, ...rest)
       }

--- a/src/middleware/ignorePristineOnChange.js
+++ b/src/middleware/ignorePristineOnChange.js
@@ -6,6 +6,7 @@ const enableSubmitOnChange = withPropsOnChange(
   ({ onChange }) => {
     return {
       onChange: (params, dispatch, props, ...rest) => {
+        if (!onChange) return
         if (props.pristine && !props.anyTouched) return
         return onChange(params, dispatch, props, ...rest)
       }

--- a/src/middleware/ignorePristineOnChange.js
+++ b/src/middleware/ignorePristineOnChange.js
@@ -1,7 +1,7 @@
 import { withPropsOnChange } from 'recompose'
 
 // Skip onChange function when form is pristine
-const enableSubmitOnChange = withPropsOnChange(
+const ignorePristineOnChange = withPropsOnChange(
   ['onChange'],
   ({ onChange }) => {
     return {
@@ -14,4 +14,4 @@ const enableSubmitOnChange = withPropsOnChange(
   }
 )
 
-export default enableSubmitOnChange
+export default ignorePristineOnChange


### PR DESCRIPTION
We shouldn't override it if it isn't defined.